### PR TITLE
Remove CsrfMiddleware and Add TIANDITU_API_KEY 

### DIFF
--- a/camp/settings.py
+++ b/camp/settings.py
@@ -212,113 +212,46 @@ STAMEN_BASEMAPS = os.environ.get('STAMEN_BASEMAPS', False)
 THUNDERFOREST_BASEMAPS = os.environ.get('THUNDERFOREST_BASEMAPS', False)
 MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN', '')
 BING_API_KEY = os.environ.get('BING_API_KEY', None)
+TIANDITU_API_KEY = os.environ.get('TIANDITU_API_KEY', None)
 
-MAP_BASELAYERS = [{
-    "source": {"ptype": "gxp_olsource"},
-    "type": "OpenLayers.Layer",
-    "args": ["No background"],
-    "name": "background",
-    "visibility": False,
-    "fixed": True,
-    "group":"background"
-}, {
-    "source": {"ptype": "gxp_olsource"},
-    "type": "OpenLayers.Layer.XYZ",
-    "title": "UNESCO",
-    "args": ["UNESCO", "http://en.unesco.org/tiles/${z}/${x}/${y}.png"],
-    "wrapDateLine": True,
-    "name": "background",
-    "attribution": "&copy; UNESCO",
-    "visibility": False,
-    "fixed": True,
-    "group":"background"
-}, {
-    "source": {"ptype": "gxp_olsource"},
-    "type": "OpenLayers.Layer.XYZ",
-    "title": "UNESCO GEODATA",
-    "args": ["UNESCO GEODATA", "http://en.unesco.org/tiles/geodata/${z}/${x}/${y}.png"],
-    "name": "background",
-    "attribution": "&copy; UNESCO",
-    "visibility": False,
-    "wrapDateLine": True,
-    "fixed": True,
-    "group":"background"
-}, {
-    "source": {"ptype": "gxp_olsource"},
-    "type": "OpenLayers.Layer.XYZ",
-    "title": "Humanitarian OpenStreetMap",
-    "args": ["Humanitarian OpenStreetMap", "http://a.tile.openstreetmap.fr/hot/${z}/${x}/${y}.png"],
-    "name": "background",
-    "attribution": "&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a>, Tiles courtesy of <a href='http://hot.openstreetmap.org/' target='_blank'>Humanitarian OpenStreetMap Team</a>",
-    "visibility": False,
-    "wrapDateLine": True,
-    "fixed": True,
-    "group":"background"
-# }, {
-#     "source": {"ptype": "gxp_olsource"},
-#     "type": "OpenLayers.Layer.XYZ",
-#     "title": "MapBox Satellite Streets",
-#     "args": ["MapBox Satellite Streets", "http://api.mapbox.com/styles/v1/mapbox/satellite-streets-v9/tiles/${z}/${x}/${y}?access_token="+MAPBOX_ACCESS_TOKEN],
-#     "name": "background",
-#     "attribution": "&copy; <a href='https://www.mapbox.com/about/maps/'>Mapbox</a> &copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> <a href='https://www.mapbox.com/feedback/' target='_blank'>Improve this map</a>",
-#     "visibility": False,
-#     "wrapDateLine": True,
-#     "fixed": True,
-#     "group":"background"
-# }, {
-#     "source": {"ptype": "gxp_olsource"},
-#     "type": "OpenLayers.Layer.XYZ",
-#     "title": "MapBox Streets",
-#     "args": ["MapBox Streets", "http://api.mapbox.com/styles/v1/mapbox/streets-v9/tiles/${z}/${x}/${y}?access_token="+MAPBOX_ACCESS_TOKEN],
-#     "name": "background",
-#     "attribution": "&copy; <a href='https://www.mapbox.com/about/maps/'>Mapbox</a> &copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a> <a href='https://www.mapbox.com/feedback/' target='_blank'>Improve this map</a>",
-#     "visibility": False,
-#     "wrapDateLine": True,
-#     "fixed": True,
-#     "group":"background"
-}, {
-    "source": {"ptype": "gxp_osmsource"},
-    "type": "OpenLayers.Layer.OSM",
-    "title": "OpenStreetMap",
-    "name": "mapnik",
-    "attribution": "&copy; <a href='http://osm.org/copyright'>OpenStreetMap</a> contributors",
-    "visibility": True,
-    "wrapDateLine": True,
-    "fixed": True,
-    "group": "background"
-}, {
-    "source": {
-        "ptype": "gxp_tianditusource"
-    },
-    "group": "background",
-    "name": "TIANDITUROAD",
-    "visibility": True,
-    "fixed": True,
-}, {
-    "source": {
-        "ptype": "gxp_tianditusource",
-    },
-    "group": "background",
-    "name": "TIANDITUIMAGE",
-    "visibility": False,
-    "fixed": True,
-}, {
-    "source": {
-        "ptype": "gxp_tianditusource"
-    },
-    "group": "background",
-    "name": "TIANDITUTERRAIN",
-    "visibility": False,
-    "fixed": True,
-}, {
-    "source": {
-        "ptype": "gxp_tianditusource"
-    },
-    "group": "background",
-    "name": "TIANDITUANNOTATION",
-    "visibility": True,
-    "fixed": True,
-}]
+if TIANDITU_API_KEY:
+    MAP_BASELAYERS += [{
+        "source": {
+            "ptype": "gxp_tianditusource",
+            "key":TIANDITU_API_KEY
+        },
+        "group": "background",
+        "name": "TIANDITUROAD",
+        "visibility": True,
+        "fixed": True,
+    }, {
+        "source": {
+            "ptype": "gxp_tianditusource",
+            "key":TIANDITU_API_KEY
+        },
+        "group": "background",
+        "name": "TIANDITUIMAGE",
+        "visibility": False,
+        "fixed": True,
+    }, {
+        "source": {
+            "ptype": "gxp_tianditusource",
+            "key":TIANDITU_API_KEY
+        },
+        "group": "background",
+        "name": "TIANDITUTERRAIN",
+        "visibility": False,
+        "fixed": True,
+    }, {
+        "source": {
+            "ptype": "gxp_tianditusource",
+            "key":TIANDITU_API_KEY
+        },
+        "group": "background",
+        "name": "TIANDITUANNOTATION",
+        "visibility": True,
+        "fixed": True,
+    }]
 
 baselayers = MAP_BASELAYERS
 MAP_BASELAYERS = [LOCAL_GEOSERVER]

--- a/camp/settings.py
+++ b/camp/settings.py
@@ -537,13 +537,36 @@ UPLOADER = {
 # for now we remove CsrfViewMiddleware, which creates failures on x-csrftoken
 # We need to fix this
 
-# MIDDLEWARE_CLASSES += (
-#     # 'django.middleware.csrf.CsrfViewMiddleware', # remove csrf because it will stop users from extranet
-#     # Add cache middleware for the per-site cache
-#     'django.middleware.cache.UpdateCacheMiddleware',
-#     'django.middleware.common.CommonMiddleware',
-#     'django.middleware.cache.FetchFromCacheMiddleware',
-# )
+MIDDLEWARE_CLASSES = (
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'dj_pagination.middleware.PaginationMiddleware',
+    # The setting below makes it possible to serve different languages per
+    # user depending on things like headers in HTTP requests.
+    'django.middleware.locale.LocaleMiddleware',
+    # 'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    # Security settings
+    'django.middleware.security.SecurityMiddleware',
+
+    # This middleware allows to print private layers for the users that have
+    # the permissions to view them.
+    # It sets temporary the involved layers as public before restoring the
+    # permissions.
+    # Beware that for few seconds the involved layers are public there could be
+    # risks.
+    # 'geonode.middleware.PrintProxyMiddleware',
+
+    # If you use SessionAuthenticationMiddleware, be sure it appears before OAuth2TokenMiddleware.
+    # SessionAuthenticationMiddleware is NOT required for using
+    # django-oauth-toolkit.
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'oauth2_provider.middleware.OAuth2TokenMiddleware',
+)
 
 # Other settings
 USE_CUSTOM_ORG_AUTHORIZATION = True


### PR DESCRIPTION
This PR completed threr things:
1. remove CsrfViewMiddleware which creates failures on x-csrftoken in camp test server.
2. add TIANDITU_API_KEY to MAP_BASELAYERS.
3. copy some templates from GeoNode and remove some code relative with google since we could not access google in camp test server.